### PR TITLE
Add support for language-markdown package

### DIFF
--- a/lib/linter-just-say-no-provider.coffee
+++ b/lib/linter-just-say-no-provider.coffee
@@ -1,6 +1,7 @@
 LinterJustSayNo =
   grammarScopes: [
     'source.gfm'
+    'text.md'
     'text.git-commit'
     'text.html.basic'
     'text.html.erb'


### PR DESCRIPTION
The [language-markdown](https://github.com/burodepeper/language-markdown) package promises to add support for more than just GFM. This includes the new CommonMark syntax, as well as front-matters, and a bunch of other goodies. As such, the linter should lint it, too.
